### PR TITLE
Add requirements to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(name='Atlas API',
       version='1.0',
       description='Python library for interacting with the Infegy Atlas API',
       author='Infegy, Inc.',
       author_email='support@infegy.com',
+      install_requires=['requests', 'python-dateutil'],
       url='https://atlas.infegy.com',
       py_modules=['atlas_api'])


### PR DESCRIPTION
This uses [setuptools instead of distutils](https://packaging.python.org/guides/tool-recommendations/#id6) so requirements can be specified so they are included when anyone installs this.